### PR TITLE
[QENG-4366] Relocate library version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/beaker-abs.gemspec
+++ b/beaker-abs.gemspec
@@ -5,7 +5,7 @@ require 'beaker-abs'
 
 Gem::Specification.new do |spec|
   spec.name          = "beaker-abs"
-  spec.version       = BeakerAbs::VERSION
+  spec.version       = BeakerAbs::Version::STRING
   spec.authors       = ["Josh Cooper", "Rick Bradley"]
   spec.email         = ["josh@puppet.com", "rick@puppet.com"]
 

--- a/lib/beaker-abs.rb
+++ b/lib/beaker-abs.rb
@@ -1,3 +1,4 @@
+require 'beaker-abs/version'
+
 module BeakerAbs
-  VERSION = "0.1.0"
 end

--- a/lib/beaker-abs/version.rb
+++ b/lib/beaker-abs/version.rb
@@ -1,0 +1,5 @@
+module BeakerAbs
+  module Version
+    STRING = '0.1.0'
+  end
+end


### PR DESCRIPTION
![](http://i.stack.imgur.com/ZJJDa.jpg)

Our pipeline tooling around automatically tagging and publishing gems expects
the gem version to be in this new location, so moving this to make that happy.

Also, added `/vendor/` to `.gitignore`.

cc @puppetlabs/cinext 
related: https://github.com/puppetlabs/cinext-docs/pull/4