### PR TITLE
(maint) Stop restricting where we can push this gem

### DIFF
--- a/beaker-abs.gemspec
+++ b/beaker-abs.gemspec
@@ -13,15 +13,6 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Adds a custom hypervisor that uses hosts provisioned by the Always Be Scheduling service.}
   spec.homepage      = "https://github.com/puppetlabs/beaker-abs"
   spec.license       = "Apache-2.0"
-
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
![](https://media.licdn.com/mpr/mpr/AAEAAQAAAAAAAAJHAAAAJDg3Y2FhMzNiLTAxNWMtNDVjNy05ZGMwLWJhNDE2MzU5NDgzNA.png)

We want this gem to be public, and this restriction is actually getting in the way on some of our jenkins instances, and not providing any value.

cc @puppetlabs/cinext