### PR TITLE
(QENG-4472) Relax version constraints

### DIFF
--- a/beaker-abs.gemspec
+++ b/beaker-abs.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 
-  spec.add_runtime_dependency "beaker", "~> 2.49"
+  spec.add_runtime_dependency "beaker", '>= 2.9.0', '< 4.0'
 end


### PR DESCRIPTION
Previously, we were pessimistically pinned to beaker 2.x, which meant
projects could not use both beaker 3 and beaker-abs simultaneously.

Beaker-abs only requires a version of beaker supporting the custom
hypervisor API. Due to a beaker bug, custom hypervisors did not work
until beaker 2.9.0 in commit d45e723cd. We also require less than beaker
4 to prevent future incompatibilities.