### PR TITLE
(DO NOT MERGE) (QENG-4466) Tag VMs

### DIFF
--- a/beaker-abs.gemspec
+++ b/beaker-abs.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "webmock"
 
   spec.add_runtime_dependency "beaker", '>= 2.9.0', '< 4.0'
 end

--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -38,8 +38,11 @@ module Beaker
         end
 
         if provisioned_hosts = type2hosts[template]
-          host['vmhostname'] = provisioned_hosts.shift['hostname']
-          tag(host)
+          resource_host = provisioned_hosts.shift
+          host['vmhostname'] = resource_host['hostname']
+          if resource_host['engine'] == 'vmpooler'
+            tag(host)
+          end
         else
           missing_hosts << host
         end

--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -1,4 +1,5 @@
 require 'beaker'
+require 'beaker/version'
 require 'json'
 
 module Beaker
@@ -22,28 +23,83 @@ module Beaker
       #   "type"     => "centos-7-i386",
       #   "engine"   => "vmpooler",
       # }
-      @resource_hosts.each do |resource_host|
-        type = resource_host['type']
-        type2hosts[type] ||= []
-        type2hosts[type] << resource_host['hostname']
-      end
+      type2hosts = @resource_hosts.group_by { |resource_host| resource_host['type'] }
+
+      missing_templates = []
+      missing_hosts = []
 
       # for each host, get a vm for that template type
       @hosts.each do |host|
         template = host['template']
 
-        raise ArgumentError.new("Failed to provision host '#{host.hostname}' because its 'template' is missing.") if template.nil?
+        if template.nil?
+          missing_templates << host
+          next
+        end
 
         if provisioned_hosts = type2hosts[template]
-          host['vmhostname'] = provisioned_hosts.shift
+          host['vmhostname'] = provisioned_hosts.shift['hostname']
+          tag(host)
         else
-          raise ArgumentError.new("Failed to provision host '#{host.hostname}', no template of type '#{host['template']}' was provided.")
+          missing_hosts << host
+        end
+      end
+
+      if host = missing_templates.first
+        raise ArgumentError.new("Failed to provision host '#{host.hostname}' because its 'template' is missing.")
+      end
+
+      if host = missing_hosts.first
+        raise ArgumentError.new("Failed to provision host '#{host.hostname}', no template of type '#{host['template']}' was provided.")
+      end
+
+      type2hosts.each_pair do |_, resource_hosts|
+        if host = resource_hosts.first
+          raise ArgumentError.new("unexpected host '#{host['hostname']}' of type '#{host['type']}' was provided")
         end
       end
     end
 
     def cleanup
       # nothing to do
+    end
+
+    private
+
+    def tag(h)
+      begin
+        uri = URI.parse(@options[:pooling_api] + '/vm/' + h['vmhostname'].split('.')[0])
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        request = Net::HTTP::Put.new(uri.request_uri)
+
+        # merge pre-defined tags with host tags
+        request.body = { 'tags' => add_tags(h) }.to_json
+
+        response = http.request(request)
+        parsed_response = JSON.parse(response.body)
+
+        unless parsed_response['ok']
+          @logger.notify "Failed to tag host '#{h['vmhostname']}'!"
+        end
+      rescue JSON::ParserError => e
+        @logger.notify "Failed to tag host '#{h['vmhostname']}'! (failed with #{e.class})"
+      rescue => e
+        @logger.notify "Failed to connect to vmpooler for tagging!: #{e.inspect}"
+      end
+    end
+
+    def add_tags(host)
+      (host[:host_tags] || {}).merge(
+        'beaker_version'    => Beaker::Version::STRING,
+        'jenkins_build_url' => @options[:jenkins_build_url],
+        'department'        => @options[:department],
+        'project'           => @options[:project],
+        'created_by'        => @options[:created_by],
+        'name'              => host.name,
+        'roles'             => host.host_hash[:roles].join(', '),
+        'cinext'            => 'true'
+      )
     end
   end
 end

--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -58,7 +58,7 @@ module Beaker
 
       type2hosts.each_pair do |_, resource_hosts|
         if host = resource_hosts.first
-          raise ArgumentError.new("unexpected host '#{host['hostname']}' of type '#{host['type']}' was provided")
+          raise ArgumentError.new("Unexpected host '#{host['hostname']}' of type '#{host['type']}' was provided")
         end
       end
     end
@@ -82,13 +82,15 @@ module Beaker
         response = http.request(request)
         parsed_response = JSON.parse(response.body)
 
-        unless parsed_response['ok']
+        if parsed_response['ok']
+          @logger.notify "Tagged host '#{h['vmhostname']}'"
+        else
           @logger.notify "Failed to tag host '#{h['vmhostname']}'!"
         end
       rescue JSON::ParserError => e
-        @logger.notify "Failed to tag host '#{h['vmhostname']}'! (failed with #{e.class})"
+        @logger.notify "Failed to tag host '#{h['vmhostname']}'!: #{e.inspect}"
       rescue => e
-        @logger.notify "Failed to connect to vmpooler for tagging!: #{e.inspect}"
+        @logger.notify "Failed to connect to vmpooler to tag host '#{h['vmhostname']}'!: #{e.inspect}"
       end
     end
 

--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -93,6 +93,8 @@ module Beaker
     end
 
     def add_tags(host)
+      # All of these tags except for 'cinext' are copied from
+      # beaker's vmpooler hypervisor.
       (host[:host_tags] || {}).merge(
         'beaker_version'    => Beaker::Version::STRING,
         'jenkins_build_url' => @options[:jenkins_build_url],

--- a/test/beaker-abs_test.rb
+++ b/test/beaker-abs_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
+require 'beaker-abs/version'
 
 class Beaker::AbsTest < Minitest::Test
   def test_that_it_has_a_version_number
-    refute_nil ::BeakerAbs::VERSION
+    assert_match(/\d+\.\d+\.\d+/, BeakerAbs::Version::STRING)
   end
 end

--- a/test/beaker/hypervisor/abs_test.rb
+++ b/test/beaker/hypervisor/abs_test.rb
@@ -382,5 +382,35 @@ describe 'Beaker::Hypervisor::Abs' do
 
       assert_requested(:put, "http://myothervmpooler.example.com/vm/m2em9v7895hk7xg")
     end
+
+    it "only tags resources whose engine is 'vmpooler'" do
+      stub_request(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg").
+        to_return(:status => 200, :body => "{\"ok\": true}")
+
+      host_hashes = {
+        'redhat7-64-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'el-7-x86_64',
+          'template'   => 'redhat-7-x86_64',
+          'roles'      => [ 'master' ]
+        },
+        'aix71-ppc-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'aix-7.1-ppc',
+          'template'   => 'aix-71-ppc',
+          'roles'      => [ 'agent' ]
+        }
+      }
+      resource_hosts = [{'hostname' => 'm2em9v7895hk7xg.delivery.puppetlabs.net',
+                         'type'     => 'redhat-7-x86_64',
+                         'engine'   => 'vmpooler'},
+                        {'hostname' => 'eb0zrfuwteq80t7.delivery.puppetlabs.net',
+                         'type'     => 'aix-71-ppc',
+                         'engine'   => 'hardware'}]
+
+      provision_hosts(host_hashes, resource_hosts)
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
   end
 end

--- a/test/beaker/hypervisor/abs_test.rb
+++ b/test/beaker/hypervisor/abs_test.rb
@@ -1,21 +1,46 @@
 require 'test_helper'
+
 require 'beaker/hypervisor/abs'
 
 describe 'Beaker::Hypervisor::Abs' do
-  def provision_hosts(host_hashes, resource_hosts)
+  let(:logger) do
+    create_logger(StringIO.new) # Set to STDOUT for debugging
+  end
+
+  let(:global_options) do
+    {
+      :jenkins_build_url => 'https://jenkins.delivery.puppetlabs.net/job/enterprise_pe-acceptance-tests_integration-system_pe_full-agent-upgrade_nightly_2016.4.x/LAYOUT=centos6-64mcd-debian7-32f-64f,LEGACY_AGENT_VERSION=NONE,PLATFORM=NOTUSED,SCM_BRANCH=2016.4.x,UPGRADE_FROM=2016.1.2,label=beaker-bigjob/13/',
+      :department => 'unknown',
+      :project => 'enterprise_pe-acceptance-tests_integration-system_pe_full-agent-upgrade_nightly_2016.4.x',
+      :created_by => 'Jenkins_coordinator_machine_account'
+    }
+  end
+
+  def provision_hosts(host_hashes, resource_hosts, options = {})
     hosts = []
 
     host_hashes.each do |name, host_hash|
       hosts << Beaker::Host.create(name, host_hash, {})
     end
 
-    abs = Beaker::Abs.new(hosts, {:abs_resource_hosts => JSON.dump(resource_hosts)})
+    options = global_options.merge({
+      :abs_resource_hosts => JSON.dump(resource_hosts),
+      :logger             => logger,
+      :pooling_api        => 'http://vmpooler.example.com'
+    }).merge(options)
+
+    abs = Beaker::Abs.new(hosts, options)
     abs.provision
 
     hosts
   end
 
   describe 'when provisioning' do
+    before :each do
+      stub_request(:put, %r{http://vmpooler.example.com/vm/.*}).
+        to_return(:status => 200, :body => "{ \"ok\": true }", :headers => {})
+    end
+
     it 'sets vmhostname for a single host' do
       host_hash = {
         'redhat7-64-1' => {
@@ -148,6 +173,210 @@ describe 'Beaker::Hypervisor::Abs' do
 
       hosts.length.must_equal(1)
       hosts[0]['vmhostname'].must_equal('eb0zrfuwteq80t7.delivery.puppetlabs.net')
+    end
+  end
+
+  def expect_request_with_tag(vm, key, value)
+    stub_request(:put, "http://vmpooler.example.com/vm/#{vm}").with do |request|
+        json = JSON.parse(request.body)
+        assert_includes(json, "tags")
+        assert_includes(json["tags"], key)
+        assert_equal(json["tags"][key], value)
+    end.to_return(:status => 200, :body => "{\"ok\": true}")
+  end
+
+  def provision_host(vm, host_tags = nil)
+    host_hash = {
+      'redhat7-64-1' => {
+        'hypervisor' => 'abs',
+        'platform'   => 'el-7-x86_64',
+        'template'   => 'redhat-7-x86_64',
+        'roles'      => [ 'agent', 'master' ]
+      }
+    }
+    host_hash['redhat7-64-1'][:host_tags] = host_tags if host_tags
+
+    resource_host =  [{'hostname' => "#{vm}.delivery.puppetlabs.net",
+                       'type'     => 'redhat-7-x86_64',
+                       'engine'   => 'vmpooler'}
+                     ]
+
+    provision_hosts(host_hash, resource_host)
+  end
+
+  describe 'when tagging' do
+    it 'includes beaker_version' do
+      expect_request_with_tag("m2em9v7895hk7xg", "beaker_version", "3.2.0")
+
+      provision_host("m2em9v7895hk7xg")
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it 'includes jenkins_build_url' do
+      expect_request_with_tag("m2em9v7895hk7xg", "jenkins_build_url", "https://jenkins.delivery.puppetlabs.net/job/enterprise_pe-acceptance-tests_integration-system_pe_full-agent-upgrade_nightly_2016.4.x/LAYOUT=centos6-64mcd-debian7-32f-64f,LEGACY_AGENT_VERSION=NONE,PLATFORM=NOTUSED,SCM_BRANCH=2016.4.x,UPGRADE_FROM=2016.1.2,label=beaker-bigjob/13/")
+
+      provision_host("m2em9v7895hk7xg")
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it 'includes department' do
+      expect_request_with_tag("m2em9v7895hk7xg", "department", "unknown")
+
+      provision_host("m2em9v7895hk7xg")
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it 'includes created_by' do
+      expect_request_with_tag("m2em9v7895hk7xg", "created_by", "Jenkins_coordinator_machine_account")
+
+      provision_host("m2em9v7895hk7xg")
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it 'includes vm name' do
+      expect_request_with_tag("m2em9v7895hk7xg", "name", "redhat7-64-1")
+
+      provision_host("m2em9v7895hk7xg")
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it 'includes roles' do
+      expect_request_with_tag("m2em9v7895hk7xg", "roles", "agent, master")
+
+      provision_host("m2em9v7895hk7xg")
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it 'includes cinext' do
+      expect_request_with_tag("m2em9v7895hk7xg", "cinext", "true")
+
+      provision_host("m2em9v7895hk7xg")
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it 'includes host-specific tags' do
+      expect_request_with_tag("m2em9v7895hk7xg", "host-specific-tag", "true")
+
+      provision_host("m2em9v7895hk7xg", "host-specific-tag" => "true")
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it 'tags all hosts passed to the provision method' do
+      stub_request(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg").
+        to_return(:status => 200, :body => "{\"ok\": true}")
+      stub_request(:put, "http://vmpooler.example.com/vm/eb0zrfuwteq80t7").
+        to_return(:status => 200, :body => "{\"ok\": true}")
+
+      host_hashes = {
+        'redhat7-64-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'el-7-x86_64',
+          'template'   => 'redhat-7-x86_64',
+          'roles'      => [ 'agent' ]
+        },
+        'ubuntu1404-64-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'ubuntu-14.04-amd64',
+          'template'   => 'ubuntu-1404-x86_64',
+          'roles'      => [ 'agent' ]
+        }
+      }
+      resource_hosts = [{'hostname' => 'm2em9v7895hk7xg.delivery.puppetlabs.net',
+                         'type'     => 'redhat-7-x86_64',
+                         'engine'   => 'vmpooler'},
+                        {'hostname' => 'eb0zrfuwteq80t7.delivery.puppetlabs.net',
+                         'type'     => 'ubuntu-1404-x86_64',
+                         'engine'   => 'vmpooler'}]
+
+      provision_hosts(host_hashes, resource_hosts)
+    end
+
+    it "only tags hosts that were passed to us, skipping missing hosts" do
+      stub_request(:put, "http://vmpooler.example.com/vm/eb0zrfuwteq80t7").
+        to_return(:status => 200, :body => "{\"ok\": true}")
+
+      host_hashes = {
+        'redhat7-64-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'el-7-x86_64',
+          'template'   => 'redhat-7-x86_64',
+          'roles'      => [ 'agent' ]
+        },
+        'ubuntu1404-64-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'ubuntu-14.04-amd64',
+          'template'   => 'ubuntu-1404-x86_64',
+          'roles'      => [ 'agent' ]
+        }
+      }
+      resource_hosts = [{'hostname' => 'eb0zrfuwteq80t7.delivery.puppetlabs.net',
+                         'type'     => 'ubuntu-1404-x86_64',
+                         'engine'   => 'vmpooler'}]
+
+      err = assert_raises(ArgumentError) do
+        provision_hosts(host_hashes, resource_hosts)
+      end
+      err.message.must_match(/no template of type 'redhat-7-x86_64' was provided/)
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/eb0zrfuwteq80t7")
+    end
+
+    it "raises if we're passed extra hosts we didn't ask for" do
+      stub_request(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg").
+        to_return(:status => 200, :body => "{\"ok\": true}")
+      stub_request(:put, "http://vmpooler.example.com/vm/eb0zrfuwteq80t7").
+        to_return(:status => 200, :body => "{\"ok\": true}")
+
+      host_hashes = {
+        'redhat7-64-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'el-7-x86_64',
+          'template'   => 'redhat-7-x86_64',
+          'roles'      => [ 'agent' ]
+        },
+      }
+      resource_hosts = [{'hostname' => 'm2em9v7895hk7xg.delivery.puppetlabs.net',
+                         'type'     => 'redhat-7-x86_64',
+                         'engine'   => 'vmpooler'},
+                        {'hostname' => 'eb0zrfuwteq80t7.delivery.puppetlabs.net',
+                         'type'     => 'ubuntu-1404-x86_64',
+                         'engine'   => 'vmpooler'}]
+
+      err = assert_raises(ArgumentError) do
+        provision_hosts(host_hashes, resource_hosts)
+      end
+      err.message.must_match(/unexpected host 'eb0zrfuwteq80t7.delivery.puppetlabs.net' of type 'ubuntu-1404-x86_64' was provided/)
+
+      assert_requested(:put, "http://vmpooler.example.com/vm/m2em9v7895hk7xg")
+    end
+
+    it "connects to the vmpooler host specified by the 'pooling_api' global option" do
+      stub_request(:put, "http://myothervmpooler.example.com/vm/m2em9v7895hk7xg").
+        to_return(:status => 200, :body => "{\"ok\": true}")
+
+      host_hashes = {
+        'redhat7-64-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'el-7-x86_64',
+          'template'   => 'redhat-7-x86_64',
+          'roles'      => [ 'agent' ]
+        }
+      }
+      resource_hosts = [{'hostname' => 'm2em9v7895hk7xg.delivery.puppetlabs.net',
+                         'type'     => 'redhat-7-x86_64',
+                         'engine'   => 'vmpooler'}]
+
+      provision_hosts(host_hashes, resource_hosts, :pooling_api => 'http://myothervmpooler.example.com')
+
+      assert_requested(:put, "http://myothervmpooler.example.com/vm/m2em9v7895hk7xg")
     end
   end
 end

--- a/test/beaker/hypervisor/abs_test.rb
+++ b/test/beaker/hypervisor/abs_test.rb
@@ -16,6 +16,10 @@ describe 'Beaker::Hypervisor::Abs' do
     }
   end
 
+  before :each do
+    ENV['ABS_RESOURCE_HOSTS'] = nil
+  end
+
   def provision_hosts(host_hashes, resource_hosts, options = {})
     hosts = []
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,4 +2,12 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'beaker-abs'
 require 'beaker'
 
+require "logger"
 require 'minitest/autorun'
+require 'webmock/minitest'
+
+WebMock.disable_net_connect!
+
+def create_logger(io)
+  Beaker::Logger.new(io, :quiet => true)
+end


### PR DESCRIPTION
- [x] only tag vmpooler platforms
- [ ] update beaker-hostgenerator calls in ci-job-configs to set pooling_api global option to vmpooler-cinext.delivery.puppetlabs.net (see https://github.com/puppetlabs/ci-job-configs/pull/1946)
