### PR TITLE
(BKR-1155) Create ssh conncection order for host based on its engine

### DIFF
--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -13,19 +13,40 @@ module Beaker
       @resource_hosts = JSON.parse(resource_hosts)
     end
 
+    # Set ssh connection method preference for each host
+    #
+    # The default order that is already set by beaker ['ip', 'vmhostname', 'hostname']
+    # If an engine is using default order provided by beaker, return nothing.
+    # If you are changing this, make sure the elements' order is changed
+    # and not the elements themselves.
+    def get_ssh_connection_preference(engine)
+      case engine
+      when /^(vmpooler|nspooler)$/
+        # putting ip last as its not set by ABS
+        return ['vmhostname', 'hostname', 'ip']
+      else
+        return ['vmhostname', 'hostname', 'ip']
+      end
+    end
+
     def provision
       type2hosts = {}
 
-      # Each resource_host is of the form:
-      # {
-      #   "hostname" => "1234567890",
+      # resource_host is of the form:
+      # [{
+      #   "hostname" => "tso2sagbmsauzcw.delivery.puppetlabs.net"
       #   "type"     => "centos-7-i386",
       #   "engine"   => "vmpooler",
-      # }
+      # },
+      # {
+      #   "hostname" => "sol10-1.delivery.puppetlabs.net"
+      #   "type"     => "solaris-10-sparc",
+      #   "engine"   => "nspooler",
+      # }]
       @resource_hosts.each do |resource_host|
         type = resource_host['type']
         type2hosts[type] ||= []
-        type2hosts[type] << resource_host['hostname']
+        type2hosts[type] << resource_host
       end
 
       # for each host, get a vm for that template type
@@ -35,7 +56,11 @@ module Beaker
         raise ArgumentError.new("Failed to provision host '#{host.hostname}' because its 'template' is missing.") if template.nil?
 
         if provisioned_hosts = type2hosts[template]
-          host['vmhostname'] = provisioned_hosts.shift
+          host['vmhostname'] = provisioned_hosts[0]['hostname']
+          if get_ssh_connection_preference(provisioned_hosts[0]['engine'])
+            host[:ssh_connection_preference] = get_ssh_connection_preference(provisioned_hosts[0]['engine'])
+          end
+          provisioned_hosts.shift
         else
           raise ArgumentError.new("Failed to provision host '#{host.hostname}', no template of type '#{host['template']}' was provided.")
         end

--- a/test/beaker-abs_test.rb
+++ b/test/beaker-abs_test.rb
@@ -2,6 +2,6 @@ require 'test_helper'
 
 class Beaker::AbsTest < Minitest::Test
   def test_that_it_has_a_version_number
-    refute_nil ::BeakerAbs::VERSION
+    refute_nil ::BeakerAbs::Version
   end
 end

--- a/test/beaker/hypervisor/abs_test.rb
+++ b/test/beaker/hypervisor/abs_test.rb
@@ -15,6 +15,57 @@ describe 'Beaker::Hypervisor::Abs' do
     hosts
   end
 
+  describe 'when setting ssh connection methods preference' do
+    it 'sets the right connection method preference when engine is vmpooler or nspooler' do
+      host_hash = {
+        'redhat7-64-1' => {
+          'hypervisor'                 => 'abs',
+          'platform'                   => 'el-7-x86_64',
+          'template'                   => 'redhat-7-x86_64',
+          'roles'                      => [ 'agent' ],
+          'ssh_connection_preference' => ['ip', 'vmhostname', 'hostname']
+        },
+        'ubuntu1404-64-1' => {
+          'hypervisor' => 'abs',
+          'platform'   => 'ubuntu-14.04-amd64',
+          'template'   => 'ubuntu-1404-x86_64',
+          'roles'      => [ 'agent' ],
+          'ssh_connection_preference' => ['ip', 'vmhostname', 'hostname']
+        }
+      }
+      resource_hosts = [{'hostname' => 'm2em9v7895hk7xg.delivery.puppetlabs.net',
+                         'type'     => 'redhat-7-x86_64',
+                         'engine'   => 'vmpooler'},
+                        {'hostname' => 'eb0zrfuwteq80t7.delivery.puppetlabs.net',
+                         'type'     => 'ubuntu-1404-x86_64',
+                         'engine'   => 'nspooler'}]
+      hosts = provision_hosts(host_hash, resource_hosts)
+
+      hosts.length.must_equal(2)
+      hosts[0]['ssh_connection_preference'].must_equal(['vmhostname', 'hostname', 'ip'])
+      hosts[1]['ssh_connection_preference'].must_equal(['vmhostname', 'hostname', 'ip'])
+    end
+
+    it "uses default case when engine's preferred connection method is not specified" do
+      host_hash = {
+        'redhat7-64-1' => {
+          'hypervisor'                 => 'abs',
+          'platform'                   => 'el-7-x86_64',
+          'template'                   => 'redhat-7-x86_64',
+          'roles'                      => [ 'agent' ],
+          'ssh_connection_preference' => ['ip', 'vmhostname', 'hostname']
+        }
+      }
+      resource_hosts = [{'hostname' => 'm2em9v7895hk7xg.delivery.puppetlabs.net',
+                         'type'     => 'redhat-7-x86_64',
+                         'engine'   => 'my_custom_engine'}]
+
+      hosts = provision_hosts(host_hash, resource_hosts)
+      hosts[0]['ssh_connection_preference'].must_equal(['vmhostname', 'hostname', 'ip'])
+    end
+
+  end
+
   describe 'when provisioning' do
     it 'sets vmhostname for a single host' do
       host_hash = {


### PR DESCRIPTION
There was ongoing conflict between difference ssh connection method preferences
among different hypervisors. VMPooler connects with vmhostname(dns) better than
ip address. Slice uses ip addresses only.

Rather than having one hardcoded connection methods preference (order), we
opened up beaker API to allow hypervisor authors to give their own preference.

In beaker-abs we dont know what engine(hypervisor) is a host coming from before
we go through the provisioning code. We have to add ssh_connection_preference to
each host's hash while provisioning. If ABS gets support for more engines, then
one has to update the switch-case statement in get_ssh_connection_perference to
set ssh connection preference for that particular engine. Right now I have added
support for engines that are already developed and are in use.

Corresponding [beaker PR](https://github.com/puppetlabs/beaker/pull/1442)