### PR TITLE
(QENG-6081) Remove beaker dependency

### DIFF
--- a/beaker-abs.gemspec
+++ b/beaker-abs.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 
-  spec.add_runtime_dependency "beaker", '>= 2.9.0', '< 4.0'
 end


### PR DESCRIPTION
In order to move beaker over to CI.Next, this must be removed to avoid
circular dependecies. This was only required because of when the
custom hypervisor API became available. At this point, that version
of beaker is 2+ years old and we can almost safely say no one
should be using version <2.9.0.