### PR TITLE
(BKR-1352) - Setting the host ip in beaker hosts hash

### DIFF
--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -50,6 +50,7 @@ module Beaker
         type = resource_host['type']
         type2hosts[type] ||= []
         type2hosts[type] << resource_host['hostname']
+        type2hosts[type] << resource_host['ip']
       end
 
       # for each host, get a vm for that template type
@@ -60,6 +61,7 @@ module Beaker
 
         if provisioned_hosts = type2hosts[template]
           host['vmhostname'] = provisioned_hosts.shift
+          host['ip'] = provisioned_hosts.shift
         else
           raise ArgumentError.new("Failed to provision host '#{host.hostname}', no template of type '#{host['template']}' was provided.")
         end


### PR DESCRIPTION
Setting the host ip in beaker hosts hash to the ip that comes back from ABS.

Because of the way DEFAULT_CONNECTION_PREFERENCE is specified in beaker/hypervisor.rb, the ip should always be used first for ssh connections.
The vmhostname value is now being set with the internal dns name of the aws machine, and this should be used everywhere that a fqdn is required in beaker/pe installer.

Tested this also with a vmpooler machine allocated by ABS (with no ip returned in the host response  object).