### PR TITLE
(BKR-1679) Provision VM/NSPooler with ABS

### DIFF
--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -2,6 +2,8 @@ require 'beaker'
 require 'json'
 
 module Beaker
+  FLOATY_BIN = `bundle info vmfloaty --path`.chomp.concat('/bin/floaty')
+
   class Abs < Beaker::Hypervisor
     def initialize(hosts, options)
       @options = options
@@ -9,7 +11,9 @@ module Beaker
       @hosts = hosts
 
       resource_hosts = ENV['ABS_RESOURCE_HOSTS'] || @options[:abs_resource_hosts]
-      raise ArgumentError.new("ABS_RESOURCE_HOSTS must be specified when using the Beaker::Abs hypervisor") if resource_hosts.nil?
+
+      raise ArgumentError.new("ABS_RESOURCE_HOSTS must be specified when using the Beaker::Abs hypervisor when provisioning") if resource_hosts.nil? && !options[:provision]
+      resource_hosts = provision_vms(hosts).to_json if resource_hosts.nil?
       @resource_hosts = JSON.parse(resource_hosts)
     end
 
@@ -73,6 +77,48 @@ module Beaker
 
     def cleanup
       # nothing to do
+    end
+
+    def provision_vms(hosts)
+      vm_request = generate_floaty_request_strings(hosts)
+
+      vm_beaker_abs = []
+      # HACKY NEED TO PROPERLY ACCESS VMFLOATY
+      # Will return a JSON Object like this:
+      # {"redhat-7-x86_64"=>["rich-apparition.delivery.puppetlabs.net", "despondent-side.delivery.puppetlabs.net"], "centos-7-x86_64"=>["firmer-vamp.delivery.puppetlabs.net"]}
+      vm_floaty_output = JSON.parse(`#{FLOATY_BIN} --service=abs get #{vm_request} --json`)
+
+      vm_floaty_output.each do |os_platform, value|
+        value.each do | hostname |
+          vm_beaker_abs.push({"hostname": hostname, "type": os_platform, "engine":"vmpooler"})
+        end
+      end
+
+      vm_beaker_abs
+    end
+
+    # Based upon the host file, this method generates a string for what we need to pass to floaty
+    # in order to generate a get request
+    def generate_floaty_request_strings(hosts)
+      list_of_possible_vms = `#{FLOATY_BIN} list --service=abs`.split
+      vm_list = {}
+      hosts.each do |host|
+        if list_of_possible_vms.include?(host[:template])
+          if vm_list.include?(host[:template])
+            vm_list[host[:template]] = vm_list[host[:template]] + 1
+          else
+            vm_list[host[:template]] = 1
+          end
+        else
+          raise ArgumentError.new("#{host.name} has a template #{host[:template]} that is not found in vmpooler or nspooler")
+        end
+      end
+      vm_request = ""
+      vm_list.each do |key, value|
+        vm_request.concat("#{key}=#{value} ")
+      end
+
+      return vm_request
     end
   end
 end


### PR DESCRIPTION
This PR introduces a way to provision with vmfloaty VMs and NSPooler
hosts, if the ABS_RESOURCE_HOSTS is not set and provision=true.
Most likely dev workflow will end up needing this.

General workflow I think should be:
1. Convert the beaker hosts file into a vmfloaty hosts string
2. Send that hosts string to vmfloaty
3. Take that floaty string we get and set that as the ABS_RESOURCE_HOSTS
4. profit?
