### PR TITLE
vmfloaty: Allow 1.x

### DIFF
--- a/beaker-abs.gemspec
+++ b/beaker-abs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "beaker", "~> 4.0"
-  spec.add_dependency "vmfloaty", ">= 1.0", "< 1.2"
+  spec.add_dependency "vmfloaty", ">= 1.0", "< 2"
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
This is required to pull in the latest vmfloaty release with in turn
allow the latest faraday (hopefully). See https://github.com/puppetlabs/vmfloaty/pull/144
for details.