### PR TITLE
(DIO-2811) Make beaker in CI respect the ssh_config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ s.add_runtime_dependency 'beaker', '~>4.0'
 s.add_runtime_dependency 'beaker-abs'
 ~~~
 
+Beaker-abs changes the default beaker (core) behavior of settings the NET::SSH ssh config to 'false' which means do not respect any of the client's ssh_config.
+If beaker-abs detects that the ssh config will be false (it was not replaced in the option files, in the HOST config etc) it sets it to the value of
+SSH_CONFIG_FILE or default to 'true'. True means it will automatically check the typical locations (~/.ssh/config, /etc/ssh_config). Respecting the ssh_config is 
+useful to specify things like no strict hostkley checking, and also to support the smallstep 'step' command in CI.
+
+
 ## Usage
 
 Create a beaker host config with `hypervisor: abs`, and pass the data from the
@@ -67,6 +73,13 @@ $ cat options.rb
 }
 $ bundle exec beaker --hosts=hosts.cfg --tests acceptance/tests --options options.rb
 ```
+
+## Environment vars
+| Var      | Description | Default |
+| ----------- | ----------- | ------ |
+| ABS_SERVICE_NAME      | When using locally via vmfloaty, the --service to use       | abs |
+| ABS_SERVICE_PRIORITY  | When using locally via vmfloaty, the priority to use        | 1 |
+| SSH_CONFIG_FILE       | If beaker-abs detects the beaker default of 'false', you can specify a file location for the ssh_config. True means it will automatically check the typical locations (~/.ssh/config, /etc/ssh_config). | true |
 
 ## Development
 

--- a/beaker-abs.gemspec
+++ b/beaker-abs.gemspec
@@ -20,6 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "beaker", "~> 4.0"
   spec.add_dependency "vmfloaty", ">= 1.0", "< 2"
+  # accept more keys, for smallstep integration
+  spec.add_dependency 'ed25519', ">= 1.2", "< 2.0"
+  spec.add_dependency 'bcrypt_pbkdf', ">= 1.0", "< 2.0"
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/lib/beaker-abs/version.rb
+++ b/lib/beaker-abs/version.rb
@@ -1,5 +1,5 @@
 module BeakerAbs
   module Version
-    STRING = '0.9.0'
+    STRING = '0.10.0'
   end
 end

--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -23,6 +23,18 @@ module Beaker
       @logger = options[:logger]
       @hosts = hosts
 
+      # set NET:SSH to use the ssh_config files if they exist
+      # beaker (upstream) defaults this settings to false
+      # NET:SSH documentation: set to true to load the default OpenSSH config files (~/.ssh/config, /etc/ssh_config), or to false to not load them,
+      # or to a file-name (or array of file-names) to load those specific configuration files. Defaults to true
+      if options[:ssh] && options[:ssh][:config] == false
+        options[:ssh][:config] = ENV['SSH_CONFIG_FILE'] || true
+        # code smell, replace existing host object (that's where NET::SSH gets the options, and the host has its own copy of the options!)
+        @hosts.each_with_index do |host, index|
+          @hosts[index] = Beaker::Host.create(host.name, host.host_hash, options)
+        end
+      end
+      
       resource_hosts = ENV['ABS_RESOURCE_HOSTS'] || @options[:abs_resource_hosts]
 
       @abs_service_name = ENV['ABS_SERVICE_NAME'] || @options[:abs_service_name] || "abs"


### PR DESCRIPTION
Befre this change, the default upstream beaker behavior is to set the net:ssh config to false
which disables following any of the ssh_config setup on the client.
Since smallstep uses a special ssh_config block, we re-enable it in beaker-abs.
That way we do not have to change the behavior upstream, and CI is already setup to
use beaker-abs.
This PR also adds to required dependencies to support ed25519 type keys in net:ssh