### PR TITLE
(maint) Remove pry-byebug require

### DIFF
--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -1,6 +1,5 @@
 require 'beaker'
 require 'json'
-require 'pry-byebug'
 require 'vmfloaty'
 require 'vmfloaty/conf'
 require 'vmfloaty/utils'


### PR DESCRIPTION
This is not needed, and now that beaker is no longer including it as a dependency, it's breaking things.