### PR TITLE
Add RE as codeowners and Migrate to Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on: workflow_dispatch
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'puppetlabs/beaker-abs'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Version
+        id: gv
+        run: |
+          echo "::set-output name=ver::$(grep VERSION lib/beaker-abs/version.rb |rev |cut -d "'" -f2 |rev)"
+      - name: Tag Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.gv.outputs.ver }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          prerelease: false
+          generateReleaseNotes: true
+      - name: Install Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+      - name: Build gem
+        run: gem build *.gemspec
+      - name: Publish gem
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: '${{ secrets.RUBYGEMS_AUTH_TOKEN }}'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,25 @@
+name: Testing
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  spec_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version:
+          - '2.7'
+          - '3.0'
+          - '3.1'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run spec tests
+      run: bundle exec rake test

--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,4 @@
+project=beaker-abs
+user=puppetlabs
+exclude_labels=maintenance
+since-tag=0.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - 2.6
-before_install:
-  - gem install bundler
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,205 @@
+# Changelog
+
+## [0.11.0](https://github.com/puppetlabs/beaker-abs/tree/0.11.0) (2022-08-11)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.10.1...0.11.0)
+
+**Merged pull requests:**
+
+- \(maint\) Remove pry-byebug require [\#28](https://github.com/puppetlabs/beaker-abs/pull/28) ([nmburgan](https://github.com/nmburgan))
+
+## [0.10.1](https://github.com/puppetlabs/beaker-abs/tree/0.10.1) (2022-04-29)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.9.0...0.10.1)
+
+**Implemented enhancements:**
+
+- \(DIO-2811\) Make beaker in CI respect the ssh\_config files [\#27](https://github.com/puppetlabs/beaker-abs/pull/27) ([sbeaulie](https://github.com/sbeaulie))
+
+**Merged pull requests:**
+
+- \(maint\) Fix minitest deprecation errors thrown during tests [\#20](https://github.com/puppetlabs/beaker-abs/pull/20) ([sbeaulie](https://github.com/sbeaulie))
+
+## [0.9.0](https://github.com/puppetlabs/beaker-abs/tree/0.9.0) (2021-07-12)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.8.1...0.9.0)
+
+**Merged pull requests:**
+
+- vmfloaty: Allow 1.x [\#26](https://github.com/puppetlabs/beaker-abs/pull/26) ([bastelfreak](https://github.com/bastelfreak))
+
+## [0.8.1](https://github.com/puppetlabs/beaker-abs/tree/0.8.1) (2020-12-14)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.8.0...0.8.1)
+
+## [0.8.0](https://github.com/puppetlabs/beaker-abs/tree/0.8.0) (2020-12-14)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.7.0...0.8.0)
+
+**Merged pull requests:**
+
+- Add examples to readme for using vmfloaty [\#22](https://github.com/puppetlabs/beaker-abs/pull/22) ([sbeaulie](https://github.com/sbeaulie))
+- \(maint\) Fix passing service or priority via ENV vars [\#21](https://github.com/puppetlabs/beaker-abs/pull/21) ([sbeaulie](https://github.com/sbeaulie))
+
+## [0.7.0](https://github.com/puppetlabs/beaker-abs/tree/0.7.0) (2020-12-10)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.6.0...0.7.0)
+
+**Merged pull requests:**
+
+- Update vmfloaty requirement from ~\> 1.0.0 to \>= 1.0, \< 1.2 [\#19](https://github.com/puppetlabs/beaker-abs/pull/19) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Update rake requirement from ~\> 10.0 to ~\> 13.0 [\#16](https://github.com/puppetlabs/beaker-abs/pull/16) ([dependabot[bot]](https://github.com/apps/dependabot))
+- remove unusable connection methods for vmpooler/nspooler [\#13](https://github.com/puppetlabs/beaker-abs/pull/13) ([sbeaulie](https://github.com/sbeaulie))
+
+## [0.6.0](https://github.com/puppetlabs/beaker-abs/tree/0.6.0) (2020-10-08)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.5.0...0.6.0)
+
+**Merged pull requests:**
+
+- Testing direct gem [\#18](https://github.com/puppetlabs/beaker-abs/pull/18) ([sbeaulie](https://github.com/sbeaulie))
+- Add Dependabot to keep thins up to date [\#15](https://github.com/puppetlabs/beaker-abs/pull/15) ([genebean](https://github.com/genebean))
+- \(MAINT\) Add CODEOWNERS file [\#14](https://github.com/puppetlabs/beaker-abs/pull/14) ([mchllweeks](https://github.com/mchllweeks))
+- \(BKR-1509\) Hypervisor usage instructions for Beaker 4.0 [\#12](https://github.com/puppetlabs/beaker-abs/pull/12) ([Dakta](https://github.com/Dakta))
+
+## [0.5.0](https://github.com/puppetlabs/beaker-abs/tree/0.5.0) (2018-02-15)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.4.0...0.5.0)
+
+**Merged pull requests:**
+
+- \(BKR-1352\) - Setting the host ip in beaker hosts hash [\#11](https://github.com/puppetlabs/beaker-abs/pull/11) ([sarahethompson](https://github.com/sarahethompson))
+
+## [0.4.0](https://github.com/puppetlabs/beaker-abs/tree/0.4.0) (2017-12-12)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.3.0...0.4.0)
+
+**Merged pull requests:**
+
+- \(QENG-6081\) Remove beaker dependency [\#10](https://github.com/puppetlabs/beaker-abs/pull/10) ([smcelmurry](https://github.com/smcelmurry))
+
+## [0.3.0](https://github.com/puppetlabs/beaker-abs/tree/0.3.0) (2017-08-14)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.2.0...0.3.0)
+
+**Merged pull requests:**
+
+- \(BKR-1155\) Override beaker's default ssh connection preference [\#9](https://github.com/puppetlabs/beaker-abs/pull/9) ([rishijavia](https://github.com/rishijavia))
+
+## [0.2.0](https://github.com/puppetlabs/beaker-abs/tree/0.2.0) (2016-10-24)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.1.3...0.2.0)
+
+**Merged pull requests:**
+
+- \(QENG-4472\) Relax version constraints [\#5](https://github.com/puppetlabs/beaker-abs/pull/5) ([joshcooper](https://github.com/joshcooper))
+- \(MAINT\) Update Development notes on releasing [\#4](https://github.com/puppetlabs/beaker-abs/pull/4) ([nwolfe](https://github.com/nwolfe))
+
+## [0.1.3](https://github.com/puppetlabs/beaker-abs/tree/0.1.3) (2016-09-16)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.1.2...0.1.3)
+
+**Merged pull requests:**
+
+- \(maint\) Stop restricting where we can push this gem [\#3](https://github.com/puppetlabs/beaker-abs/pull/3) ([rick](https://github.com/rick))
+
+## [0.1.2](https://github.com/puppetlabs/beaker-abs/tree/0.1.2) (2016-09-16)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.1.1...0.1.2)
+
+# qe_beaker-abs_bump_and_tag_master - History
+## Tags
+* [LATEST - 14 Aug, 2017 (26840bd3)](#LATEST)
+* [0.2.0 - 24 Oct, 2016 (44ff3935)](#0.2.0)
+* [0.1.3 - 16 Sep, 2016 (6f1ced08)](#0.1.3)
+* [0.1.2 - 16 Sep, 2016 (b914ae60)](#0.1.2)
+* [0.1.1 - 16 Sep, 2016 (10ee39cf)](#0.1.1)
+
+## Details
+### <a name = "LATEST">LATEST - 14 Aug, 2017 (26840bd3)
+
+* (GEM) update beaker-abs version to 0.3.0 (26840bd3)
+
+* Merge pull request #9 from rishijavia/BKR-1155-third_attempt (859cb1ec)
+
+
+```
+Merge pull request #9 from rishijavia/BKR-1155-third_attempt
+
+(BKR-1155) Override beaker's default ssh connection preference
+```
+* (BKR-1155) Override beaker's default ssh connection preference (8bab8a1c)
+
+### <a name = "0.2.0">0.2.0 - 24 Oct, 2016 (44ff3935)
+
+* (HISTORY) update beaker-abs history for gem release 0.2.0 (44ff3935)
+
+* (GEM) update beaker-abs version to 0.2.0 (4c14d730)
+
+* Merge pull request #5 from puppetlabs/beaker3-conflict (54001ff7)
+
+
+```
+Merge pull request #5 from puppetlabs/beaker3-conflict
+
+(QENG-4472) Relax version constraints
+```
+* (QENG-4472) Relax version constraints (574d1d95)
+
+
+```
+(QENG-4472) Relax version constraints
+
+Previously, we were pessimistically pinned to beaker 2.x, which meant
+projects could not use both beaker 3 and beaker-abs simultaneously.
+
+Beaker-abs only requires a version of beaker supporting the custom
+hypervisor API. Due to a beaker bug, custom hypervisors did not work
+until beaker 2.9.0 in commit d45e723cd. We also require less than beaker
+4 to prevent future incompatibilities.
+```
+* (MAINT) Update Development notes on releasing (80972ba9)
+
+* Merge pull request #4 from puppetlabs/update-dev-section-in-readme (9f4acbe1)
+
+
+```
+Merge pull request #4 from puppetlabs/update-dev-section-in-readme
+
+(MAINT) Update Development notes on releasing
+```
+### <a name = "0.1.3">0.1.3 - 16 Sep, 2016 (6f1ced08)
+
+* (HISTORY) update beaker-abs history for gem release 0.1.3 (6f1ced08)
+
+* (GEM) update beaker-abs version to 0.1.3 (3d6ed7b7)
+
+* Merge pull request #3 from puppetlabs/drop-gem-publish-restrictions (c0c786a4)
+
+
+```
+Merge pull request #3 from puppetlabs/drop-gem-publish-restrictions
+
+(maint) Stop restricting where we can push this gem
+```
+* (maint) Stop restricting where we can push this gem (ba107b81)
+
+
+```
+(maint) Stop restricting where we can push this gem
+
+We want this gem to be public, and this restriction is actually getting
+in the way on some of our jenkins instances, and not providing any value.
+```
+### <a name = "0.1.2">0.1.2 - 16 Sep, 2016 (b914ae60)
+
+* (HISTORY) update beaker-abs history for gem release 0.1.2 (b914ae60)
+
+* (GEM) update beaker-abs version to 0.1.2 (b0ee39d0)
+
+### <a name = "0.1.1">0.1.1 - 16 Sep, 2016 (10ee39cf)
+
+* Initial release.
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @puppetlabs/dio
+* @puppetlabs/dio @puppetlabs/release-engineering

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # beaker-abs
 
+[![Gem Version](https://badge.fury.io/rb/beaker-abs.svg)](https://badge.fury.io/rb/beaker-abs)
+[![Testing](https://github.com/puppetlabs/beaker-abs/actions/workflows/testing.yml/badge.svg)](https://github.com/puppetlabs/beaker-abs/actions/workflows/testing.yml)
+
+- [Description](#description)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Using vmfloaty](#using-vmfloaty)
+    - [Examples](#examples)
+- [Environment vars](#environment-vars)
+- [Releasing](#releasing)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Description
+
 Implements a Beaker hypervisor that makes hosts provisioned by the AlwaysBeScheduling service available to a Beaker run.
 
 ## Installation
@@ -8,20 +23,19 @@ Beaker will automatically load the appropriate hypervisors for any given hosts f
 
 As of Beaker 4.0, all hypervisor and DSL extension libraries have been removed and are no longer dependencies. In order to use a specific hypervisor or DSL extension library in your project, you will need to include them alongside Beaker in your Gemfile or project.gemspec. E.g.
 
-~~~ruby
+```ruby
 # Gemfile
 gem 'beaker', '~>4.0'
 gem 'beaker-abs'
 # project.gemspec
 s.add_runtime_dependency 'beaker', '~>4.0'
 s.add_runtime_dependency 'beaker-abs'
-~~~
+```
 
 Beaker-abs changes the default beaker (core) behavior of settings the NET::SSH ssh config to 'false' which means do not respect any of the client's ssh_config.
 If beaker-abs detects that the ssh config will be false (it was not replaced in the option files, in the HOST config etc) it sets it to the value of
-SSH_CONFIG_FILE or default to 'true'. True means it will automatically check the typical locations (~/.ssh/config, /etc/ssh_config). Respecting the ssh_config is 
+SSH_CONFIG_FILE or default to 'true'. True means it will automatically check the typical locations (~/.ssh/config, /etc/ssh_config). Respecting the ssh_config is
 useful to specify things like no strict hostkley checking, and also to support the smallstep 'step' command in CI.
-
 
 ## Usage
 
@@ -42,7 +56,7 @@ HOSTS:
 
 Run beaker as:
 
-```
+```bash
 env ABS_RESOURCE_HOSTS=<data> beaker --hosts hosts.yaml
 ```
 
@@ -52,7 +66,7 @@ This is typically used in a CI scenario, where the jenkins run-me-maybe plugin i
 ### Using vmfloaty
 
 If you do not specify a ABS_RESOURCE_HOSTS and request to provision via the beaker options, beaker-abs will fallback to using
-your vmfloaty configuration. By default it will look for the service named 'abs'. The name can also be configured via 
+your vmfloaty configuration. By default it will look for the service named 'abs'. The name can also be configured via
 the environment variable ABS_SERVICE_NAME or the top level option in the hosts file abs_service_name. Similarly, the priority defaults to "1" which means
 it will take precedence over CI tests. Be careful not to run a CI test with this option. The priority can be configured via
 the environment variable ABS_SERVICE_PRIORITY or the top level option in the hosts file abs_service_priority.
@@ -60,12 +74,14 @@ the environment variable ABS_SERVICE_PRIORITY or the top level option in the hos
 #### Examples
 
 Changing from default priority 1 to 3 via env var
-```
+
+```bash
 ABS_SERVICE_PRIORITY=3 bundle exec beaker --provision --hosts=hosts.cfg --tests acceptance/tests
 ```
 
 Changing the service name to look for in ~/.vmfloaty.yml via a beaker option file
-```
+
+```bash
 $ cat options.rb
 {
   provision: 'true',
@@ -75,31 +91,26 @@ $ bundle exec beaker --hosts=hosts.cfg --tests acceptance/tests --options option
 ```
 
 ## Environment vars
+
 | Var      | Description | Default |
 | ----------- | ----------- | ------ |
 | ABS_SERVICE_NAME      | When using locally via vmfloaty, the --service to use       | abs |
 | ABS_SERVICE_PRIORITY  | When using locally via vmfloaty, the priority to use        | 1 |
 | SSH_CONFIG_FILE       | If beaker-abs detects the beaker default of 'false', you can specify a file location for the ssh_config. True means it will automatically check the typical locations (~/.ssh/config, /etc/ssh_config). | true |
 
-## Development
+## Releasing
 
-After checking out the repo, run `bundle install --path .bundle` to install dependencies. Then, run `bundle exec rake test` to run the tests.
+Open a release prep PR and run the release action:
 
-To release a new version, run the [release pipeline](https://jenkins-qe.delivery.puppetlabs.net/job/qe_beaker-abs_init-multijob_master/) 
-(infrastructure access is required) and provide the following parameters:
-
-- PUBLIC: Whether to release the gem to rubygems.org
-- version: Desired version to release
-
-The pipeline will update the version number in `version.rb`, create a git tag for the version, push git commits and tags to
-GitHub, and optionally push the `.gem` file to [rubygems.org](https://rubygems.org).
+1. Bump the "version" parameter in `lib/beaker-abs/version.rb` appropriately based merged pull requests since the last release.
+2. Update the changelog by running `docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator:1.16.2 github_changelog_generator --future-release <INSERT_NEXT_VERSION>`
+3. Commit and push changes to a new branch, then open a pull request against `main` and be sure to add the "maintenance" label.
+4. After the pull request is approved and merged, then navigate to Actions --> Release Action --> run workflow --> Branch: main --> Run workflow.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/puppetlabs/beaker-abs.
-
+Bug reports and pull requests are welcome on GitHub at <https://github.com/puppetlabs/beaker-abs>.
 
 ## License
 
 The gem is available as open source under the terms of the [Apache-2.0 License](https://opensource.org/licenses/Apache-2.0).
-


### PR DESCRIPTION
1. Added release-engineering to codeowners
2. Renamed default branch to main.
3. Migrated testing (Travis) and releasing (Jenkins) to GitHub Actions
4. Added the `RUBYGEMS_AUTH_TOKEN` secret.
5. Implemented changelog
6. Updated formatting in Readme
7. Will update the required checks post-merge.