### PR TITLE
(PUP-11786) Beaker 5 compatibility

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,6 +14,7 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ def location_for(place, fake_version = nil)
 end
 
 group :testing do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 5.0')
 end

--- a/beaker-abs.gemspec
+++ b/beaker-abs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "beaker", "~> 4.0"
+  spec.add_dependency "beaker", "~> 5.0"
   spec.add_dependency "vmfloaty", ">= 1.0", "< 2"
   # accept more keys, for smallstep integration
   spec.add_dependency 'ed25519', ">= 1.2", "< 2.0"


### PR DESCRIPTION
Vox Pupuli has released Beaker 5, which drops older (< 2.7) Ruby compatibility and adds compatibility for Ruby 3.2

This commit adds testing for Ruby 3.2 and sets the dependency on Beaker to ~> 5.0.