### PR TITLE
1.0.0 release prep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,13 @@
 version: 2
 updates:
+- package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
-    time: "13:00"
+    interval: "weekly"
   open-pull-requests-limit: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,95 @@
-name: Release
+name: Tag Release & Push Gem
 
 on: workflow_dispatch
 
 jobs:
   release:
+    name: Validate Docs, Tag, and Push Gem
     runs-on: ubuntu-latest
     if: github.repository == 'puppetlabs/beaker-abs'
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Get Version
-        id: gv
-        run: |
-          echo "::set-output name=ver::$(grep VERSION lib/beaker-abs/version.rb |rev |cut -d "'" -f2 |rev)"
-      - name: Tag Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.gv.outputs.ver }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          draft: false
-          prerelease: false
-          generateReleaseNotes: true
-      - name: Install Ruby 2.7
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-      - name: Build gem
-        run: gem build *.gemspec
-      - name: Publish gem
-        run: |
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem push *.gem
-        env:
-          GEM_HOST_API_KEY: '${{ secrets.RUBYGEMS_AUTH_TOKEN }}'
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.ref }}
+        clean: true
+        fetch-depth: 0
+
+    - name: Get New Version
+      id: nv
+      run: |
+        version=$(grep VERSION lib/beaker-abs/version.rb |rev |cut -d "'" -f2 |rev)
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "Found version $version from lib/beaker-abs/version.rb"
+
+    - name: Get Current Version
+      uses: actions/github-script@v6
+      id: cv
+      with:
+        script: |
+          const { data: response } = await github.rest.repos.getLatestRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          })
+          console.log(`The latest release is ${response.tag_name}`)
+          return response.tag_name
+        result-encoding: string
+
+    - name: Generate Changelog
+      uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
+      with:
+        args: >-
+          --future-release ${{ steps.nv.outputs.version }}
+      env:
+        CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Validate Changelog
+      run : |
+        set -e
+        if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+          echo "Here is the current git status:"
+          git status
+          echo
+          echo "The following changes were detected:"
+          git --no-pager diff
+          echo "Uncommitted PRs found in the changelog. Please submit a release prep PR of changes after running './release-prep'"
+          exit 1
+        fi
+
+    - name: Generate Release Notes
+      uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
+      with:
+        args: >-
+          --since-tag ${{ steps.cv.outputs.result }}
+          --future-release ${{ steps.nv.outputs.version }}
+          --output release-notes.md
+      env:
+        CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Tag Release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ steps.nv.outputs.version }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        bodyfile: release-notes.md
+        draft: false
+        prerelease: false
+
+    - name: Set up Ruby 3.2
+      uses: actions/setup-ruby@v1
+      with:
+        version: 3.2.x
+
+    - name: Build gem
+      run: gem build *.gemspec
+
+    - name: Publish gem
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
           - '3.1'
           - '3.2'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.0.0](https://github.com/puppetlabs/beaker-abs/tree/1.0.0) (2023-03-28)
+
+[Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.11.0...1.0.0)
+
+**Breaking changes:**
+
+- \(PUP-11786\) Beaker 5 compatibility [\#32](https://github.com/puppetlabs/beaker-abs/pull/32) ([mhashizume](https://github.com/mhashizume))
+
+**Merged pull requests:**
+
+- \(RE-15111\) Add Mend Scanning [\#31](https://github.com/puppetlabs/beaker-abs/pull/31) ([yachub](https://github.com/yachub))
+- \(RE-14811\) Remove DIO as codeowners [\#30](https://github.com/puppetlabs/beaker-abs/pull/30) ([yachub](https://github.com/yachub))
+- Add RE as codeowners and Migrate to Actions [\#29](https://github.com/puppetlabs/beaker-abs/pull/29) ([yachub](https://github.com/yachub))
+
 ## [0.11.0](https://github.com/puppetlabs/beaker-abs/tree/0.11.0) (2022-08-11)
 
 [Full Changelog](https://github.com/puppetlabs/beaker-abs/compare/0.10.1...0.11.0)

--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 [![Gem Version](https://badge.fury.io/rb/beaker-abs.svg)](https://badge.fury.io/rb/beaker-abs)
 [![Testing](https://github.com/puppetlabs/beaker-abs/actions/workflows/testing.yml/badge.svg)](https://github.com/puppetlabs/beaker-abs/actions/workflows/testing.yml)
 
-- [Description](#description)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [Using vmfloaty](#using-vmfloaty)
-    - [Examples](#examples)
-- [Environment vars](#environment-vars)
-- [Releasing](#releasing)
-- [Contributing](#contributing)
-- [License](#license)
+- [beaker-abs](#beaker-abs)
+  - [Description](#description)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Using vmfloaty](#using-vmfloaty)
+      - [Examples](#examples)
+  - [Environment vars](#environment-vars)
+  - [Releasing](#releasing)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Description
 
@@ -103,7 +104,7 @@ $ bundle exec beaker --hosts=hosts.cfg --tests acceptance/tests --options option
 Open a release prep PR and run the release action:
 
 1. Bump the "version" parameter in `lib/beaker-abs/version.rb` appropriately based merged pull requests since the last release.
-2. Update the changelog by running `docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator:1.16.2 github_changelog_generator --future-release <INSERT_NEXT_VERSION>`
+2. Run `./release-prep` to update `Gemfile.lock` and `CHANGELOG.md`.
 3. Commit and push changes to a new branch, then open a pull request against `main` and be sure to add the "maintenance" label.
 4. After the pull request is approved and merged, then navigate to Actions --> Release Action --> run workflow --> Branch: main --> Run workflow.
 

--- a/lib/beaker-abs/version.rb
+++ b/lib/beaker-abs/version.rb
@@ -1,5 +1,5 @@
 module BeakerAbs
   module Version
-    STRING = '0.11.0'
+    STRING = '1.0.0'
   end
 end

--- a/release-prep
+++ b/release-prep
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# bundle install
+docker run -it --rm \
+  -v $(pwd):/app \
+  ruby:3.2-slim-bullseye \
+  /bin/bash -c 'apt-get update -qq && apt-get install -y --no-install-recommends build-essential git make && cd /app && gem install bundler && bundle install --jobs 3; echo "LOCK_FILE_UPDATE_EXIT_CODE=$?"'
+
+# Update Changelog
+docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
+  githubchangeloggenerator/github-changelog-generator:1.16.2 \
+  github_changelog_generator --future-release $(grep STRING lib/beaker-abs/version.rb |rev |cut -d "'" -f2 |rev)


### PR DESCRIPTION
With the updated release process I'll manually publish the previous 0.11.0 release on the existing tag post-merge so that the release notes for this release can be generated when running the workflow.