### PR TITLE
Fix minitest after 5.19.0

### DIFF
--- a/test/beaker/hypervisor/abs_test.rb
+++ b/test/beaker/hypervisor/abs_test.rb
@@ -176,13 +176,13 @@ describe 'Beaker::Hypervisor::Abs' do
     end
 
     it 'does not call set_ssh_connection_preference method if hypervisor does not responds' do
-      hypervisor_mock = MiniTest::Mock.new
+      hypervisor_mock = Minitest::Mock.new
       1.times { hypervisor_mock.expect(:respond_to?, false, [:set_ssh_connection_preference]) }
       provision_hosts({}, {})
     end
 
     it 'calls set_ssh_connection_preference method if beaker responds' do
-      hypervisor_mock = MiniTest::Mock.new
+      hypervisor_mock = Minitest::Mock.new
       2.times { hypervisor_mock.expect(:respond_to?, true, [:set_ssh_connection_preference]) }
       provision_hosts({}, {})
     end


### PR DESCRIPTION
Fix minitest after breaking change in https://github.com/minitest/minitest/blob/master/History.rdoc#label-5.19.0+-2F+2023-07-26