### PR TITLE
(PA-8450) Fix beaker destroy when ABS_RESOURCE_HOSTS is unset

### DIFF
--- a/lib/beaker/hypervisor/abs.rb
+++ b/lib/beaker/hypervisor/abs.rb
@@ -39,9 +39,7 @@ module Beaker
       @abs_service_name = ENV['ABS_SERVICE_NAME'] || @options[:abs_service_name] || "abs"
       @abs_service_priority = ENV['ABS_SERVICE_PRIORITY'] || @options[:abs_service_priority] || "1"
 
-      raise ArgumentError.new("ABS_RESOURCE_HOSTS must be specified when using the Beaker::Abs hypervisor when provisioning") if resource_hosts.nil? && !options[:provision]
-      resource_hosts = provision_vms(hosts).to_json if resource_hosts.nil?
-      @resource_hosts = JSON.parse(resource_hosts)
+      @resource_hosts = resource_hosts ? JSON.parse(resource_hosts) : []
     end
 
     def connection_preference(host)
@@ -65,6 +63,11 @@ module Beaker
     end
 
     def provision
+      if @resource_hosts.empty? && !@hosts.empty?
+        raise ArgumentError, "ABS_RESOURCE_HOSTS must be specified when using the Beaker::Abs hypervisor" unless @options[:provision]
+        @resource_hosts = JSON.parse(provision_vms(@hosts).to_json)
+      end
+
       type2hosts = {}
 
       # Each resource_host is of the form:
@@ -104,7 +107,22 @@ module Beaker
     end
 
     def cleanup
-      # nothing to do
+      return if ENV['ABS_RESOURCE_HOSTS'] || @options[:abs_resource_hosts]
+
+      hostnames = @hosts.map(&:hostname)
+      return if hostnames.empty?
+
+      verbose = false
+      config = Conf.read_config
+      cli = Clifloaty.new(@abs_service_name, @abs_service_priority)
+      abs_service = Service.new(cli, config)
+      abs_service.delete(verbose, hostnames).each_pair do |hostname, result|
+        if result['ok']
+          @logger.info("Destroyed #{hostname}")
+        else
+          @logger.warn("Failed to destroy #{hostname}")
+        end
+      end
     end
 
     def provision_vms(hosts)

--- a/test/beaker/hypervisor/abs_test.rb
+++ b/test/beaker/hypervisor/abs_test.rb
@@ -2,6 +2,25 @@ require 'test_helper' # THIS IS MINITEST
 require 'beaker/hypervisor/abs'
 require 'vmfloaty/utils'
 
+class FakeLogger
+  attr_reader :infos, :warns
+
+  def initialize
+    @infos = []
+    @warns = []
+  end
+
+  def info(msg)
+    @infos << msg
+  end
+
+  def warn(msg)
+    @warns << msg
+  end
+
+  def notify(*); end
+end
+
 describe 'Beaker::Hypervisor::Abs' do
   def provision_hosts(host_hashes, resource_hosts)
     hosts = []
@@ -17,16 +36,13 @@ describe 'Beaker::Hypervisor::Abs' do
   end
 
   describe 'initialize' do
-    it 'pending: does not raise when neither ABS_RESOURCE_HOSTS nor provision: true is set' do
-      assert_raises(ArgumentError) do
-        Beaker::Abs.new([], {:provision => false})
-      end
+    it 'does not raise when neither ABS_RESOURCE_HOSTS nor provision: true is set' do
+      Beaker::Abs.new([], {:provision => false})
     end
 
-    it 'pending: initializes resource_hosts to an empty array when neither is provided' do
-      assert_raises(ArgumentError) do
-        Beaker::Abs.new([], {:provision => false})
-      end
+    it 'initializes resource_hosts to an empty array when neither is provided' do
+      abs = Beaker::Abs.new([], {:provision => false})
+      _(abs.instance_variable_get(:@resource_hosts)).must_equal []
     end
 
     it 'parses ABS_RESOURCE_HOSTS from the environment' do
@@ -208,9 +224,16 @@ describe 'Beaker::Hypervisor::Abs' do
 
     it 'raises in provision when there are no resource hosts and provision: false' do
       host = Beaker::Host.create('myhost', {'hypervisor' => 'abs', 'platform' => 'el-7-x86_64', 'template' => 'centos-7'}, {})
-      assert_raises(ArgumentError) do
-        Beaker::Abs.new([host], {:provision => false})
-      end
+      abs = Beaker::Abs.new([host], {:provision => false})
+      assert_raises(ArgumentError) { abs.provision }
+    end
+
+    it 'calls provision_vms and assigns vmhostname when resource_hosts is empty and provision: true' do
+      provisioned = [{'hostname' => 'new.example.com', 'type' => 'centos-7', 'engine' => 'beaker-abs'}]
+      host = Beaker::Host.create('myhost', {'hypervisor' => 'abs', 'platform' => 'el-7-x86_64', 'template' => 'centos-7'}, {})
+      abs = Beaker::Abs.new([host], {:provision => true})
+      abs.stub(:provision_vms, provisioned) { abs.provision }
+      _(host['vmhostname']).must_equal 'new.example.com'
     end
 
     it 'does not call set_ssh_connection_preference method if hypervisor does not responds' do
@@ -225,6 +248,82 @@ describe 'Beaker::Hypervisor::Abs' do
       provision_hosts({}, {})
     end
 
+  end
+
+  describe 'cleanup' do
+    def make_abs(hosts = [], extra_options = {})
+      Beaker::Abs.new(hosts, {:logger => FakeLogger.new, :provision => false}.merge(extra_options))
+    end
+
+    it 'is a no-op when ABS_RESOURCE_HOSTS env var is set' do
+      ENV['ABS_RESOURCE_HOSTS'] = '[]'
+      begin
+        called = false
+        Service.stub(:new, ->(*) { called = true }) do
+          make_abs.cleanup
+        end
+        refute called
+      ensure
+        ENV['ABS_RESOURCE_HOSTS'] = nil
+      end
+    end
+
+    it 'is a no-op when abs_resource_hosts option is set' do
+      called = false
+      Service.stub(:new, ->(*) { called = true }) do
+        make_abs([], {:abs_resource_hosts => '[]'}).cleanup
+      end
+      refute called
+    end
+
+    it 'is a no-op when there are no hosts' do
+      called = false
+      Service.stub(:new, ->(*) { called = true }) do
+        make_abs([]).cleanup
+      end
+      refute called
+    end
+
+    it 'calls vmfloaty delete with all hostnames' do
+      hosts = [Beaker::Host.create('foo.example.com', {'hypervisor' => 'abs', 'platform' => 'el-7-x86_64'}, {}),
+               Beaker::Host.create('bar.example.com', {'hypervisor' => 'abs', 'platform' => 'el-7-x86_64'}, {})]
+      service_mock = Minitest::Mock.new
+      service_mock.expect(:delete,
+                          { 'foo.example.com' => { 'ok' => true }, 'bar.example.com' => { 'ok' => true } },
+                          [false, ['foo.example.com', 'bar.example.com']])
+      Conf.stub(:read_config, {}) do
+        Service.stub(:new, ->(*) { service_mock }) do
+          make_abs(hosts).cleanup
+        end
+      end
+      service_mock.verify
+    end
+
+    it 'logs info for each successfully deleted host' do
+      hosts = [Beaker::Host.create('foo.example.com', {'hypervisor' => 'abs', 'platform' => 'el-7-x86_64'}, {})]
+      abs = make_abs(hosts)
+      service_mock = Minitest::Mock.new
+      service_mock.expect(:delete, { 'foo.example.com' => { 'ok' => true } }, [false, ['foo.example.com']])
+      Conf.stub(:read_config, {}) do
+        Service.stub(:new, ->(*) { service_mock }) do
+          abs.cleanup
+        end
+      end
+      _(abs.instance_variable_get(:@logger).infos.first).must_match(/foo\.example\.com/)
+    end
+
+    it 'logs a warning for each host that fails to delete' do
+      hosts = [Beaker::Host.create('foo.example.com', {'hypervisor' => 'abs', 'platform' => 'el-7-x86_64'}, {})]
+      abs = make_abs(hosts)
+      service_mock = Minitest::Mock.new
+      service_mock.expect(:delete, { 'foo.example.com' => { 'ok' => false } }, [false, ['foo.example.com']])
+      Conf.stub(:read_config, {}) do
+        Service.stub(:new, ->(*) { service_mock }) do
+          abs.cleanup
+        end
+      end
+      _(abs.instance_variable_get(:@logger).warns.first).must_match(/foo\.example\.com/)
+    end
   end
 
 end

--- a/test/beaker/hypervisor/abs_test.rb
+++ b/test/beaker/hypervisor/abs_test.rb
@@ -16,6 +16,37 @@ describe 'Beaker::Hypervisor::Abs' do
     hosts
   end
 
+  describe 'initialize' do
+    it 'pending: does not raise when neither ABS_RESOURCE_HOSTS nor provision: true is set' do
+      assert_raises(ArgumentError) do
+        Beaker::Abs.new([], {:provision => false})
+      end
+    end
+
+    it 'pending: initializes resource_hosts to an empty array when neither is provided' do
+      assert_raises(ArgumentError) do
+        Beaker::Abs.new([], {:provision => false})
+      end
+    end
+
+    it 'parses ABS_RESOURCE_HOSTS from the environment' do
+      resource_hosts = [{'hostname' => 'foo.example.com', 'type' => 'centos-7', 'engine' => 'vmpooler'}]
+      ENV['ABS_RESOURCE_HOSTS'] = resource_hosts.to_json
+      begin
+        abs = Beaker::Abs.new([], {})
+        _(abs.instance_variable_get(:@resource_hosts)).must_equal resource_hosts
+      ensure
+        ENV['ABS_RESOURCE_HOSTS'] = nil
+      end
+    end
+
+    it 'parses abs_resource_hosts from options' do
+      resource_hosts = [{'hostname' => 'bar.example.com', 'type' => 'el-7', 'engine' => 'nspooler'}]
+      abs = Beaker::Abs.new([], {:abs_resource_hosts => resource_hosts.to_json})
+      _(abs.instance_variable_get(:@resource_hosts)).must_equal resource_hosts
+    end
+  end
+
   describe 'when ABS_RESOURCE_HOSTS is not ready' do
     it '#provision_vms works properly' do
 
@@ -173,6 +204,13 @@ describe 'Beaker::Hypervisor::Abs' do
 
       _(hosts.length).must_equal(1)
       _(hosts[0]['vmhostname']).must_equal('eb0zrfuwteq80t7.delivery.puppetlabs.net')
+    end
+
+    it 'raises in provision when there are no resource hosts and provision: false' do
+      host = Beaker::Host.create('myhost', {'hypervisor' => 'abs', 'platform' => 'el-7-x86_64', 'template' => 'centos-7'}, {})
+      assert_raises(ArgumentError) do
+        Beaker::Abs.new([host], {:provision => false})
+      end
     end
 
     it 'does not call set_ssh_connection_preference method if hypervisor does not responds' do

--- a/test/beaker/hypervisor/abs_test.rb
+++ b/test/beaker/hypervisor/abs_test.rb
@@ -324,6 +324,35 @@ describe 'Beaker::Hypervisor::Abs' do
       end
       _(abs.instance_variable_get(:@logger).warns.first).must_match(/foo\.example\.com/)
     end
+
+    it 'deletes by vmhostname not beaker host name' do
+      host = Beaker::Host.create('redhat7-64-1', {
+        'hypervisor' => 'abs',
+        'platform'   => 'el-7-x86_64',
+        'template'   => 'centos-7'
+      }, {})
+      host['vmhostname'] = 'abs-hostname.delivery.puppetlabs.net'
+      abs = make_abs([host])
+
+      deleted_hostnames = []
+      service_stub = ->(*) {
+        Object.new.tap { |s|
+          s.define_singleton_method(:delete) { |_, names|
+            deleted_hostnames.concat(names)
+            names.map { |n| [n, {'ok' => true}] }.to_h
+          }
+        }
+      }
+
+      Conf.stub(:read_config, {}) do
+        Service.stub(:new, service_stub) do
+          abs.cleanup
+        end
+      end
+
+      assert_includes deleted_hostnames, 'abs-hostname.delivery.puppetlabs.net'
+      refute_includes deleted_hostnames, 'redhat7-64-1'
+    end
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,13 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+# exclude warnings in 3rd party code
+module WarningFilter
+  def warn(message, category: nil)
+    super unless Gem.path.any? { |p| message.include?(p) }
+  end
+end
+Warning.prepend(WarningFilter)
+
 require 'beaker-abs'
 require 'beaker'
 


### PR DESCRIPTION
beaker-abs operates in two provisioning modes: Either the host lifetime is owned
by an external process or beaker-abs owns it. In the first case, the already
allocated hosts are passed in via ABS_RESOURCE_HOSTS, typically by the
run-me-maybe jenkins plugin. In the second case, beaker-abs provisions hosts
using vmfloaty.

In the first mode, `beaker destroy` is a noop, since the external process owns
the lifetime. In the second mode, an error was raised:

    ABS_RESOURCE_HOSTS must be specified when using the Beaker::Abs hypervisor when provisioning (ArgumentError)

The problem was the `initialize` method validated the provisioning mode, but
it's called by `beaker destroy`. This commit moves the validation logic to the
`provision` method. The behavior is unchanged: If ABS_RESOURCE_HOSTS is
provided, we use that. Otherwise, if provision option is true, then provision
using vmfloaty. By default the option is true[1] Otherwise raise.

[1] https://github.com/voxpupuli/beaker/blob/fc0e891c6de30ec5ea41ef38fe43b9f16a48d79b/lib/beaker/options/presets.rb#L153

```
❯ export BEAKER_ABS_VERSION=file:///home/josh/work/beaker-abs
❯ bundle install
Fetching gem metadata from https://rubygems.org/.........
...
❯ bundle exec beaker-hostgenerator redhat9-64a --hypervisor abs --disable-default-role --osinfo-version 1 > hosts.yaml
❯ export BEAKER_HOSTS=hosts.yaml 
❯ bundle exec beaker init --hosts hosts.yaml --options-file config/aio/options.rb --test-tag-or=risk:high,audit:high
Writing configured options to disk
Options written to .beaker/subcommand_options.yaml
❯ bundle exec beaker provision
Hypervisor for redhat9-64-1 is abs
Beaker::Hypervisor, found some abs boxes to create
...
Waiting 10s (x12) Total: 0 / 1, Ondemand VMPooler: redhat-9-x86_64 (ready: 0, pending: 1)
...
wild-homogenate.delivery.puppetlabs.net (redhat9-64-1) executed in 0.08 seconds
updating HOSTS key in subcommand_options
❯ bundle exec beaker destroy  
Hypervisor for wild-homogenate.delivery.puppetlabs.net is abs
Beaker::Hypervisor, found some abs boxes to create
Destroyed wild-homogenate.delivery.puppetlabs.net
```